### PR TITLE
fix: ensure dotfiles setup works correctly on Apple Silicon Mac

### DIFF
--- a/.gitconfig.local
+++ b/.gitconfig.local
@@ -1,2 +1,3 @@
 [user]
   name =
+  email =

--- a/.zsh/function.zsh
+++ b/.zsh/function.zsh
@@ -31,9 +31,9 @@ function ide {
 }
 
 # fzf
-if [ -e /usr/local/opt/fzf/shell/completion.zsh ]; then
-  source /usr/local/opt/fzf/shell/key-bindings.zsh
-  source /usr/local/opt/fzf/shell/completion.zsh
+if [ -e /opt/homebrew/opt/fzf/shell/completion.zsh ]; then
+  source /opt/homebrew/opt/fzf/shell/key-bindings.zsh
+  source /opt/homebrew/opt/fzf/shell/completion.zsh
 fi
 
 # Docker

--- a/.zsh/zinit.zsh
+++ b/.zsh/zinit.zsh
@@ -18,7 +18,7 @@ fi
 [[ ! -f ~/.zsh/.p10k.zsh ]] || source ~/.zsh/.p10k.zsh
 
 zinit ice wait'!0' atinit"zpcompinit; zpcdreplay"
-zinit light zdharma/fast-syntax-highlighting
+zinit light zdharma-continuum/fast-syntax-highlighting
 
 zinit ice wait'!0' lucid
 zinit snippet OMZ::lib/completion.zsh

--- a/.zshenv
+++ b/.zshenv
@@ -8,7 +8,7 @@ export JAVA_HOME=/opt/homebrew/opt/openjdk
 export PATH=$PATH:/opt/homebrew/bin
 
 # direnv
-export EDITOR=vim
+export EDITOR=nvim
 
 # android
 export ANDROID_HOME=~/Library/Android/sdk
@@ -17,17 +17,17 @@ export PATH=$PATH:~/Library/Android/sdk/tools
 export PATH=$PATH:~/Library/Android/sdk/platform-tools
 
 # rust
-. "$HOME/.cargo/env"
+[ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
 
 # deno
 export PATH="$HOME/.deno/bin:$PATH"
 
 # cpp
-export PATH="/usr/local/opt/llvm/bin:$PATH"
+export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
 
 # pnpm
 export PNPM_HOME="$HOME/Library/pnpm"
 export PATH="$PNPM_HOME:$PATH"
 
 # pipx
-export PATH="~/.local/bin:$PATH"
+export PATH="$HOME/.local/bin:$PATH"

--- a/.zshrc
+++ b/.zshrc
@@ -17,7 +17,6 @@ bindkey '^R' history-incremental-search-backward
 bindkey '^A' beginning-of-line
 
 # edit command
-export EDITOR='nvim'
 autoload -Uz edit-command-line
 zle -N edit-command-line
 bindkey "^e" edit-command-line
@@ -38,19 +37,18 @@ eval "$(/opt/homebrew/bin/mise activate zsh)"
 export PATH="/opt/homebrew/opt/mysql@8.0/bin:$PATH"
 
 # alias
-[ ~/.zsh/alias.zsh ] && source ~/.zsh/alias.zsh
+[ -f ~/.zsh/alias.zsh ] && source ~/.zsh/alias.zsh
 
 # my function
-[ ~/.zsh/function.zsh ] && source ~/.zsh/function.zsh
+[ -f ~/.zsh/function.zsh ] && source ~/.zsh/function.zsh
 
 # local config
-[ ~/.zshrc.local ] && source ~/.zshrc.local
+[ -f ~/.zshrc.local ] && source ~/.zshrc.local
 
 # plugins
-[ ~/.zsh/zinit.zsh ] && source ~/.zsh/zinit.zsh
+[ -f ~/.zsh/zinit.zsh ] && source ~/.zsh/zinit.zsh
 
 # ruby
 eval "$(rbenv init - zsh)"
 
-export PATH="$GOROOT/bin:$PATH"
-export PATH="$PATH:$GOPATH/bin"
+export PATH="$HOME/go/bin:$PATH"


### PR DESCRIPTION
## Summary

Fix `install.sh` to complete setup successfully on a new MacBook (Apple Silicon).

### Critical fixes
- Add Xcode Command Line Tools pre-check (fails when git is not installed)
- Create `/usr/local/bin` with `mkdir -p` if it doesn't exist
- Add existence check before sourcing `~/.cargo/env`
- Add `mise activate bash` so Go tools are found on PATH

### Warning fixes
- Change `chsh` to `sudo chsh` to prevent hanging in pipeline
- Replace `~` with `$HOME` in pipx PATH (tilde not expanded inside double quotes)
- Update fzf / LLVM paths for Apple Silicon (`/opt/homebrew/`)
- Add `-f` flag to file existence checks
- Unify `EDITOR` to `nvim` (remove duplication between `.zshenv` and `.zshrc`)
- Replace background `espanso daemon` launch with manual instruction
- Switch zinit plugins to `zdharma-continuum` (active fork)

### Minor fixes
- Add `set -e`, fix variable quoting, remove duplicate `defaults write`
- Simplify `$GOROOT/$GOPATH` to `$HOME/go/bin`
- Add `email` field to `.gitconfig.local`
- Change `exec $SHELL -l` to `exec /opt/homebrew/bin/zsh -l`

## Test plan
- [x] `shellcheck install.sh` passes with no errors
- [ ] Start a new zsh session and confirm no errors
- [ ] Dry-run `install.sh` on a VM or separate machine if possible