### PR TITLE
fix: remove stale rbenv init from .zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -48,7 +48,4 @@ export PATH="/opt/homebrew/opt/mysql@8.0/bin:$PATH"
 # plugins
 [ -f ~/.zsh/zinit.zsh ] && source ~/.zsh/zinit.zsh
 
-# ruby
-eval "$(rbenv init - zsh)"
-
 export PATH="$HOME/go/bin:$PATH"


### PR DESCRIPTION
## Summary
- Remove `eval "$(rbenv init - zsh)"` from `.zshrc` that was causing `zsh: command not found: rbenv` on every shell startup
- rbenv was already removed from the Brewfile but the shell initialization line remained

## Test plan
- [ ] Open a new terminal and verify no `command not found: rbenv` error
- [ ] Run `source ~/.zshrc` and confirm it completes without errors