### PR TITLE
feat: show monthly cumulative cost in statusline using ccusage

### DIFF
--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -4,7 +4,8 @@ input=$(cat)
 model=$(echo "$input" | jq -r '.model.display_name // "Unknown"')
 short_model=$(echo "$model" | sed 's/Claude //' | sed 's/ (.*//')
 used=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
-cost=$(echo "$input" | jq -r '.cost.total_cost_usd // empty')
+monthly_cost=$(npx ccusage@16.2.0 monthly --json --order desc 2>/dev/null \
+  | jq -r '.monthly[0].totalCost * 100 | round / 100')
 duration_ms=$(echo "$input" | jq -r '.cost.total_duration_ms // empty')
 cwd=$(echo "$input" | jq -r '.cwd // empty')
 
@@ -33,9 +34,8 @@ else
   line="$line | --% context"
 fi
 
-if [ -n "$cost" ] && [ "$cost" != "null" ]; then
-  cost_fmt=$(printf "%.2f" "$cost")
-  line="$line | 💰 \033[32m\$${cost_fmt}\033[0m"
+if [ -n "$monthly_cost" ] && [ "$monthly_cost" != "null" ]; then
+  line="$line | 💰 \033[32m\$${monthly_cost}\033[0m monthly"
 fi
 
 if [ -n "$duration_ms" ] && [ "$duration_ms" != "null" ]; then


### PR DESCRIPTION
## Summary

- Replace session-level cost (`cost.total_cost_usd`) with monthly cumulative cost in the statusline
- Use `ccusage` (via `npx ccusage@16.2.0 monthly --json`) to fetch the current month's total API usage cost
- Display format: `💰 $XX.XX monthly`

## Test plan

- [ ] Run `~/.claude/statusline.sh` directly and verify monthly cost is displayed
- [ ] Open Claude Code and confirm the statusline shows `💰 $XX.XX monthly`
- [ ] Open a second Claude Code session and confirm cost is still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)