### PR TITLE
chore: update dotfiles config and fix espanso service setup

### DIFF
--- a/.claude/rules/development-workflow.md
+++ b/.claude/rules/development-workflow.md
@@ -36,3 +36,9 @@ The Feature Implementation Workflow describes the development pipeline: research
    - Detailed commit messages
    - Follow conventional commits format
    - See [git-workflow.md](./git-workflow.md) for commit message format and PR process
+
+5. **Pre-Review Checks**
+   - Verify all automated checks (CI/CD) are passing
+   - Resolve any merge conflicts
+   - Ensure branch is up to date with target branch
+   - Only request review after these checks pass

--- a/.ssh/config
+++ b/.ssh/config
@@ -1,23 +1,14 @@
 # Added by OrbStack: 'orb' SSH host for Linux machines
 # This only works if it's at the top of ssh_config (before any Host blocks).
-# This won't be added again if you remove it.
 Include ~/.orbstack/ssh/config
 Include ./config.local
 
-Host github.com
-  HostName github.com
+Host *
   AddKeysToAgent yes
   UseKeychain yes
-  IdentityFile ~/.ssh/id_github
-  User git
-  TCPKeepAlive yes
   IdentitiesOnly yes
+  IdentityFile ~/.ssh/id_ed25519
 
-Host github.com.private
-  HostName github.com
-  AddKeysToAgent yes
-  UseKeychain yes
-  IdentityFile ~/.ssh/id_github_private
+Host github.com
   User git
   TCPKeepAlive yes
-  IdentitiesOnly yes

--- a/Brewfile.lock.json
+++ b/Brewfile.lock.json
@@ -1662,34 +1662,6 @@
           }
         }
       },
-      "rbenv": {
-        "version": "1.3.0",
-        "bottle": {
-          "rebuild": 1,
-          "root_url": "https://ghcr.io/v2/homebrew/core",
-          "files": {
-            "all": {
-              "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/rbenv/blobs/sha256:8c1ae8d76748e0140a458cd4c83b2f6ed83da17777940f7878ce5348ede8aeff",
-              "sha256": "8c1ae8d76748e0140a458cd4c83b2f6ed83da17777940f7878ce5348ede8aeff"
-            }
-          }
-        }
-      },
-      "ruby-build": {
-        "version": "20241105",
-        "bottle": {
-          "rebuild": 0,
-          "root_url": "https://ghcr.io/v2/homebrew/core",
-          "files": {
-            "all": {
-              "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/ruby-build/blobs/sha256:417b5c6509e39101c5c9b609292c2e8dc09710c33e0e51120218ace8368cfd65",
-              "sha256": "417b5c6509e39101c5c9b609292c2e8dc09710c33e0e51120218ace8368cfd65"
-            }
-          }
-        }
-      },
       "protobuf": {
         "version": "28.3",
         "bottle": {

--- a/install.sh
+++ b/install.sh
@@ -25,56 +25,66 @@ if [ ! -d "$DOTFILES_HOME" ]; then
   git remote set-url origin git@github.com:locol23/dotfiles.git
   cd "$CURRENT_DIRECTORY"
 
-  # Mac
-  # Dock
-  defaults write com.apple.dock autohide -bool true
-  defaults write com.apple.dock autohide-delay -float 0
-  defaults write com.apple.dock autohide-time-modifier -float 0.7
-  defaults write com.apple.dock magnification -bool true
-  defaults write com.apple.dock mineffect -string "scale"
-  defaults write com.apple.dock mru-spaces -bool "false"
   defaults write com.apple.dock persistent-apps -array
-  defaults write com.apple.dock show-recents -bool "false"
-  defaults write com.apple.dock tilesize -int 55
-  killall Dock
-  # Keyboad
-  defaults write -g InitialKeyRepeat -int 15
-  defaults write -g KeyRepeat -int 1
-  # Trackpad
-  defaults write com.apple.AppleMultitouchTrackpad Clicking -bool "true"
-  defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad Clicking -bool "true"
-  defaults -currentHost write -g com.apple.mouse.tapBehavior -bool "true"
-  defaults write -g com.apple.trackpad.scaling 3
-  defaults write com.apple.AppleMultitouchTrackpad TrackpadFourFingerVertSwipeGesture -int 2
-  defaults write com.apple.AppleMultitouchTrackpad TrackpadThreeFingerVertSwipeGesture -int 0
-  defaults write com.apple.dock showMissionControlGestureEnabled -boolean true
-  defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadFourFingerVertSwipeGesture -int 2
-  defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadThreeFingerVertSwipeGesture -int 0
-  # Battery
-  defaults write com.apple.menuextra.battery ShowPercent -string "YES"
-  # Finder
-  defaults write com.apple.finder DisableAllAnimations -bool true
-  defaults write com.apple.finder AppleShowAllFiles -bool true
-  defaults write NSGlobalDomain AppleShowAllExtensions -bool true
-  defaults write com.apple.finder ShowStatusBar -bool true
-  defaults write com.apple.finder ShowPathbar -bool true
-  defaults write com.apple.finder FXDefaultSearchScope -string "SCcf"
-  defaults write com.apple.finder FXEnableExtensionChangeWarning -bool false
-  # Terminal
-  defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true
-  defaults write com.apple.desktopservices DSDontWriteUSBStores -bool true
 
   # Create dotfiles command for updating tools
   sudo mkdir -p /usr/local/bin
   sudo ln -sf "$DOTFILES_HOME/install.sh" /usr/local/bin/dotfiles
 fi
 
+# Mac
+# Language
+defaults write NSGlobalDomain AppleLanguages -array "en-US" "ja-JP"
+# Appearance
+defaults write NSGlobalDomain AppleInterfaceStyle -string "Dark"
+# Dock
+defaults write com.apple.dock autohide -bool true
+defaults write com.apple.dock autohide-delay -float 0
+defaults write com.apple.dock autohide-time-modifier -float 0.7
+defaults write com.apple.dock magnification -bool true
+defaults write com.apple.dock mineffect -string "scale"
+defaults write com.apple.dock mru-spaces -bool "false"
+defaults write com.apple.dock show-recents -bool "false"
+defaults write com.apple.dock tilesize -int 55
+killall Dock
+# Keyboard
+defaults write -g InitialKeyRepeat -int 15
+defaults write -g KeyRepeat -int 1
+# Spotlight (disable Cmd+Space to use Raycast instead)
+/usr/libexec/PlistBuddy -c "Set :AppleSymbolicHotKeys:64:enabled false" ~/Library/Preferences/com.apple.symbolichotkeys.plist
+/System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u
+# Raycast
+defaults write com.raycast.macos raycastGlobalHotkey "Command-49"
+# Trackpad
+defaults write com.apple.AppleMultitouchTrackpad Clicking -bool "true"
+defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad Clicking -bool "true"
+defaults -currentHost write -g com.apple.mouse.tapBehavior -bool "true"
+defaults write -g com.apple.trackpad.scaling 3
+defaults write com.apple.AppleMultitouchTrackpad TrackpadFourFingerVertSwipeGesture -int 2
+defaults write com.apple.AppleMultitouchTrackpad TrackpadThreeFingerVertSwipeGesture -int 0
+defaults write com.apple.dock showMissionControlGestureEnabled -boolean true
+defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadFourFingerVertSwipeGesture -int 2
+defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadThreeFingerVertSwipeGesture -int 0
+# Battery
+defaults write com.apple.menuextra.battery ShowPercent -string "YES"
+# Finder
+defaults write com.apple.finder DisableAllAnimations -bool true
+defaults write com.apple.finder AppleShowAllFiles -bool true
+defaults write NSGlobalDomain AppleShowAllExtensions -bool true
+defaults write com.apple.finder ShowStatusBar -bool true
+defaults write com.apple.finder ShowPathbar -bool true
+defaults write com.apple.finder FXDefaultSearchScope -string "SCcf"
+defaults write com.apple.finder FXEnableExtensionChangeWarning -bool false
+# Terminal
+defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true
+defaults write com.apple.desktopservices DSDontWriteUSBStores -bool true
+
 # Homebrew and Formula
 if not_installed brew; then
   export PATH=$PATH:/opt/homebrew/bin
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 fi
-brew bundle --file $DOTFILES_HOME/Brewfile
+brew bundle --file $DOTFILES_HOME/Brewfile --verbose
 brew services start ollama
 
 # Ghostty
@@ -185,7 +195,8 @@ ln -sf $DOTFILES_HOME/.ssh/config ~/.ssh/
 # espanso
 mkdir -p ~/Library/Application\ Support/espanso/match
 ln -sf "$DOTFILES_HOME"/espanso/*.yml ~/Library/Application\ Support/espanso/match/
+espanso service register 2>/dev/null
 echo
-echo "espanso: Accessibility 権限を手動で付与してから 'espanso daemon' を実行してください"
+echo "espanso: Accessibility 権限を手動で付与してから 'espanso service start' を実行してください"
 
 exec /opt/homebrew/bin/zsh -l

--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -32,7 +32,7 @@
   "nvim-cmp": { "branch": "main", "commit": "a1d504892f2bc56c2e79b65c6faded2fd21f3eca" },
   "nvim-lint": { "branch": "master", "commit": "eab58b48eb11d7745c11c505e0f3057165902461" },
   "nvim-lsp-notify": { "branch": "main", "commit": "9541bdde0b84b7a33a24dbc2eccc3df33d4a0cdb" },
-  "nvim-lspconfig": { "branch": "master", "commit": "cb5bc0b2b35a6d513e3298d285db81453e791f4f" },
+  "nvim-lspconfig": { "branch": "master", "commit": "8a9378a822719346a0288fa004dab302ca3c0a8f" },
   "nvim-navic": { "branch": "master", "commit": "f5eba192f39b453675d115351808bd51276d9de5" },
   "nvim-notify": { "branch": "master", "commit": "8701bece920b38ea289b457f902e2ad184131a5d" },
   "nvim-tree.lua": { "branch": "master", "commit": "85d1145ac71c1b8e1423862c78165a1f609faf60" },


### PR DESCRIPTION
## Summary

- **Fix espanso daemon not starting**: Register espanso as a launchd service via `espanso service register` and update the guidance message from `espanso daemon` to `espanso service start`
- **Reorganize macOS defaults**: Move settings out of the initial-clone block so they apply on every `install.sh` run; add language (en-US/ja-JP), dark mode, Spotlight disable (for Raycast), and Raycast hotkey config
- **Simplify SSH config**: Use wildcard `Host *` with ed25519 key instead of per-host duplicated settings; remove unused `github.com.private` host
- **Clean up dependencies**: Remove rbenv/ruby-build from Brewfile.lock.json (already removed from Brewfile in #273)
- **Minor improvements**: Add `--verbose` flag to `brew bundle`, update nvim-lspconfig lock

## Test plan

- [ ] Run `espanso service register && espanso service start` and verify `espanso status` shows running
- [ ] Type `:espanso` in a text editor and verify it expands to "Hi there!"
- [ ] Run `install.sh` on a fresh environment and verify macOS defaults are applied
- [ ] Verify SSH access to GitHub still works with `ssh -T git@github.com`