### PR TITLE
chore: add --enable-auto-mode flag to claude alias

### DIFF
--- a/.zsh/alias.zsh
+++ b/.zsh/alias.zsh
@@ -20,4 +20,4 @@ alias ll="ls -l"
 alias tf=terraform
 alias tg=terragrunt
 alias p=pnpm
-alias c=claude
+alias c='claude --enable-auto-mode'


### PR DESCRIPTION
## Summary
- Update the `c` alias to launch Claude Code with `--enable-auto-mode` enabled by default
- Fix quoting so the flag is properly included in the alias

## Test plan
- [ ] Run `source .zsh/alias.zsh` and verify `alias c` outputs `claude --enable-auto-mode`