### PR TITLE
chore: add --effort high flag to claude alias

### DIFF
--- a/.zsh/alias.zsh
+++ b/.zsh/alias.zsh
@@ -20,4 +20,4 @@ alias ll="ls -l"
 alias tf=terraform
 alias tg=terragrunt
 alias p=pnpm
-alias c='claude --enable-auto-mode'
+alias c='claude --enable-auto-mode --effort high'


### PR DESCRIPTION
## Summary
- Add `--effort high` flag to the `claude` alias (`c`) for consistent deep reasoning in daily development work

## Test plan
- [ ] Open a new shell session and verify `alias c` outputs `claude --enable-auto-mode --effort high`
- [ ] Run `c` and confirm Claude Code starts with effort level set to high