### PR TITLE
chore: show seconds in menu bar clock and fix battery percentage

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -65,8 +65,14 @@ defaults write com.apple.AppleMultitouchTrackpad TrackpadThreeFingerVertSwipeGes
 defaults write com.apple.dock showMissionControlGestureEnabled -boolean true
 defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadFourFingerVertSwipeGesture -int 2
 defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadThreeFingerVertSwipeGesture -int 0
-# Battery
-defaults write com.apple.menuextra.battery ShowPercent -string "YES"
+# Battery (show icon + percentage in menu bar via Control Center)
+defaults write com.apple.controlcenter "NSStatusItem Visible Battery" -bool true
+defaults -currentHost write com.apple.controlcenter BatteryShowPercentage -bool true
+# Clock (show seconds)
+defaults write com.apple.menuextra.clock DateFormat -string "EEE d MMM HH:mm:ss"
+defaults write com.apple.menuextra.clock FlashDateSeparators -bool false
+defaults write com.apple.menuextra.clock IsAnalog -bool false
+killall SystemUIServer 2>/dev/null || true
 # Finder
 defaults write com.apple.finder DisableAllAnimations -bool true
 defaults write com.apple.finder AppleShowAllFiles -bool true

--- a/install.sh
+++ b/install.sh
@@ -69,8 +69,7 @@ defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadThreeF
 defaults write com.apple.controlcenter "NSStatusItem Visible Battery" -bool true
 defaults -currentHost write com.apple.controlcenter BatteryShowPercentage -bool true
 # Clock (show seconds)
-defaults write com.apple.menuextra.clock DateFormat -string "EEE d MMM HH:mm:ss"
-defaults write com.apple.menuextra.clock FlashDateSeparators -bool false
+defaults write com.apple.menuextra.clock ShowSeconds -bool true
 defaults write com.apple.menuextra.clock IsAnalog -bool false
 killall SystemUIServer 2>/dev/null || true
 # Finder


### PR DESCRIPTION
## Summary
- Show seconds in the macOS menu bar clock via `com.apple.menuextra.clock DateFormat`.
- Fix battery percentage display: the legacy `com.apple.menuextra.battery ShowPercent` key has been a no-op since macOS Big Sur. Switch to the Control Center keys (`NSStatusItem Visible Battery` and `BatteryShowPercentage`).
- `killall SystemUIServer` so the changes take effect immediately.

## Test plan
- [ ] Run `bash ~/.dotfiles/install.sh` on macOS (Sequoia/Sonoma).
- [ ] Verify the menu bar clock shows `HH:mm:ss`.
- [ ] Verify the battery icon and percentage are visible in the menu bar.
- [ ] Confirm values: `defaults read com.apple.menuextra.clock DateFormat`, `defaults read com.apple.controlcenter "NSStatusItem Visible Battery"`, `defaults -currentHost read com.apple.controlcenter BatteryShowPercentage`.