### PR TITLE
chore(claude.md): remove redundant rules-layout paragraph

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,9 +1,8 @@
 # Coding Guidelines
 
-Project-wide coding standards, language-specific guides, testing philosophy, and team workflow live under `~/.claude/rules/` (canonical [ECC](https://github.com/affaan-m/everything-claude-code) layout — `common/` always-on, `golang/` `typescript/` `web/` activated by `paths:` frontmatter). `install.sh` re-syncs the ECC subdirs on every run.
-
 ## General Notes
 
 - Document architectural discoveries or configuration insights in this file.
 - Add universally important findings that apply across projects here.
-- Anything language- or stack-specific belongs in the corresponding `rules/<lang>/*.md` instead.
+- Anything language- or stack-specific belongs in the corresponding
+  `rules/<lang>/*.md` instead.


### PR DESCRIPTION
## Summary

The opening paragraph in `.claude/CLAUDE.md` described where rule files live and how `paths:` frontmatter gates them. That information:

- Does not change Claude's behavior — rules under `~/.claude/rules/` are auto-loaded into the session context already.
- Is duplicated in `install.sh` (sync block) and each `rules/<lang>/local.md` (intro line).

Drop it. CLAUDE.md now keeps only the title and the `General Notes` section, which is the only Claude-actionable content.

## Test plan

- [ ] `cat .claude/CLAUDE.md` — file is now ~6 lines, only title + General Notes
- [ ] Open a project and confirm rule files still load (no behavior change)