### PR TITLE
fix(nvim): include hidden files in telescope live_grep

### DIFF
--- a/nvim/lua/plugins/telescope.lua
+++ b/nvim/lua/plugins/telescope.lua
@@ -92,6 +92,17 @@ return {
 			},
 			defaults = {
 				hidden = true,
+				vimgrep_arguments = {
+					"rg",
+					"--color=never",
+					"--no-heading",
+					"--with-filename",
+					"--line-number",
+					"--column",
+					"--smart-case",
+					"--hidden",
+					"--glob=!.git/",
+				},
 				preview = {
 					treesitter = false,
 				},


### PR DESCRIPTION
## Summary
- `<leader>fg`（telescope `live_grep`）で `.zsh/alias.zsh` の `gbd` のような hidden ディレクトリ配下のファイルがヒットしなかったのを修正。
- `defaults.hidden = true` は `find_files` 系にしか効かず、`live_grep` は内部で `vimgrep_arguments`（= ripgrep に渡す引数）を使うため、ripgrep のデフォルトで dot-prefixed ディレクトリがスキップされていた。
- `defaults.vimgrep_arguments` を明示し、telescope のデフォルト7引数に `--hidden` と `--glob=!.git/`（`.git/` 配下のノイズ除外）を追加。

## Test plan
- [ ] Neovim を再起動して telescope 設定を再読込
- [ ] `<leader>fg` → `gbd` を入力し、`.zsh/alias.zsh:2` がヒットすることを確認
- [ ] `.config/`, `.claude/` 配下のファイルも検索対象に入ることを確認
- [ ] `.git/` 配下はヒットしないことを確認
- [ ] `<leader>ff`（find_files）の挙動が今まで通り（hidden 含む）であることを確認