### PR TITLE
fix(tmux): stop install.sh from disabling mouse clicks in Ghostty/tmux

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -33,7 +33,7 @@ set-option -g status-interval 1
 
 set-option -g default-terminal screen-256color
 set -g terminal-overrides 'xterm:colors=256'
-setw -g mouse
+set -g mouse on
 set-window-option -g mode-keys vi
 set-window-option -g automatic-rename off
 set -g base-index 1

--- a/install.sh
+++ b/install.sh
@@ -219,7 +219,9 @@ ln -sf $DOTFILES_HOME/.tigrc ~/
 
 # Tmux
 ln -sf $DOTFILES_HOME/.tmux.conf ~/
-tmux source-file ~/.tmux.conf 2>/dev/null || true
+if tmux info >/dev/null 2>&1; then
+  tmux source-file ~/.tmux.conf || warn "tmux source-file reported an error (check ~/.tmux.conf)"
+fi
 
 # BTT
 ln -sf $DOTFILES_HOME/bttconfig.json ~/bttconfig.json


### PR DESCRIPTION
## Summary

Running `install.sh` from inside an existing tmux session disabled the mouse in
Ghostty/tmux — clicking and pane switching stopped working, and relaunching
Ghostty + reattaching did not recover it. This fixes the root cause and hardens
the tmux config reload in `install.sh`.

## Root cause

`.tmux.conf` enabled mouse with the **value-less** form `setw -g mouse`. In tmux
a value-less flag **toggles** the option rather than setting it (verified:
`off -> on -> off -> on`).

- tmux reads the config **once** at server startup: `setw -g mouse` flips the
  default `off -> on`, so mouse worked (it had, since 2019).
- `install.sh` re-sources the config into the **already-running, mouse-on**
  server (`tmux source-file ~/.tmux.conf`), applying the toggle a **second** time
  → `on -> off`. Clicks and pane switching die.

This explains every symptom: it's tmux/Ghostty-only (other apps are unaffected),
it survives a Ghostty relaunch + reattach (the running server keeps the off state;
reattach does not re-read the config), and `tmux set -g mouse on` fixed it live
(an explicit set does not toggle).

## Why it never surfaced before

It's a toggle, so it only flips off when the config is applied an extra (odd)
number of times onto a live mouse-on server. A normal boot applies it once
(`-> on`). Running `install.sh` **from inside a running tmux session** applies it
again (`-> off`). Prior runs presumably had no live tmux server, or tmux was
restarted afterward (a fresh server re-reads the config `-> on`), so the off
state never stuck.

## Changes

- **`.tmux.conf`** — `setw -g mouse` → `set -g mouse on`. Explicit and idempotent,
  so re-sourcing (at startup or from `install.sh`) always lands on `on` and never
  toggles off. `mouse` is a server/session option, so `set -g` is also the
  canonical command.
- **`install.sh`** — stop silently swallowing tmux reload failures. Guard on a
  running server with `tmux info` (avoids a spurious warning on a fresh install
  where no tmux server exists — `tmux source-file` exits non-zero there), and
  surface genuine reload errors via the existing `warn` helper instead of
  `2>/dev/null || true`.

## Test plan

- [x] Reproduced end-to-end on an isolated tmux socket (tmux 3.7):
  - `setw -g mouse`: startup `-> mouse on`; re-source `-> mouse off` (bug)
  - `set -g mouse on`: startup `-> on`; re-source `-> on`; again `-> on` (fixed)
- [x] `bash -n install.sh` passes.
- [x] `tmux info` guard skips the source with no server (no spurious warning).
- [x] Live server: `tmux show -g mouse` → `mouse on`.
- [ ] Re-run `install.sh` from inside a tmux session and confirm clicking /
  pane switching still work afterward.
