### PR TITLE
chore: herdr follow-ups, path-scoped web rules, nvim pin bump

### DIFF
--- a/.claude/rules/common/git-workflow.md
+++ b/.claude/rules/common/git-workflow.md
@@ -9,7 +9,7 @@
 
 Types: feat, fix, refactor, docs, test, chore, perf, ci
 
-Note: Attribution disabled globally via ~/.claude/settings.json.
+Note: To disable co-author attribution on commits, set `"includeCoAuthoredBy": false` in `~/.claude/settings.json` (Claude Code appends `Co-Authored-By` by default; ECC does not ship this setting).
 
 ## Pull Request Workflow
 

--- a/.claude/rules/web/coding-style.md
+++ b/.claude/rules/web/coding-style.md
@@ -1,3 +1,15 @@
+---
+paths:
+  - "**/*.css"
+  - "**/*.scss"
+  - "**/*.sass"
+  - "**/*.less"
+  - "**/*.html"
+  - "**/*.tsx"
+  - "**/*.jsx"
+  - "**/*.vue"
+  - "**/*.svelte"
+---
 > This file extends [common/coding-style.md](../common/coding-style.md) with web-specific frontend content.
 
 # Web Coding Style

--- a/.claude/rules/web/design-quality.md
+++ b/.claude/rules/web/design-quality.md
@@ -1,3 +1,15 @@
+---
+paths:
+  - "**/*.css"
+  - "**/*.scss"
+  - "**/*.sass"
+  - "**/*.less"
+  - "**/*.html"
+  - "**/*.tsx"
+  - "**/*.jsx"
+  - "**/*.vue"
+  - "**/*.svelte"
+---
 > This file extends [common/patterns.md](../common/patterns.md) with web-specific design-quality guidance.
 
 # Web Design Quality Standards

--- a/.claude/rules/web/hooks.md
+++ b/.claude/rules/web/hooks.md
@@ -1,3 +1,15 @@
+---
+paths:
+  - "**/*.css"
+  - "**/*.scss"
+  - "**/*.sass"
+  - "**/*.less"
+  - "**/*.html"
+  - "**/*.tsx"
+  - "**/*.jsx"
+  - "**/*.vue"
+  - "**/*.svelte"
+---
 > This file extends [common/hooks.md](../common/hooks.md) with web-specific hook recommendations.
 
 # Web Hooks

--- a/.claude/rules/web/patterns.md
+++ b/.claude/rules/web/patterns.md
@@ -1,3 +1,15 @@
+---
+paths:
+  - "**/*.css"
+  - "**/*.scss"
+  - "**/*.sass"
+  - "**/*.less"
+  - "**/*.html"
+  - "**/*.tsx"
+  - "**/*.jsx"
+  - "**/*.vue"
+  - "**/*.svelte"
+---
 > This file extends [common/patterns.md](../common/patterns.md) with web-specific patterns.
 
 # Web Patterns

--- a/.claude/rules/web/performance.md
+++ b/.claude/rules/web/performance.md
@@ -1,3 +1,15 @@
+---
+paths:
+  - "**/*.css"
+  - "**/*.scss"
+  - "**/*.sass"
+  - "**/*.less"
+  - "**/*.html"
+  - "**/*.tsx"
+  - "**/*.jsx"
+  - "**/*.vue"
+  - "**/*.svelte"
+---
 > This file extends [common/performance.md](../common/performance.md) with web-specific performance content.
 
 # Web Performance Rules

--- a/.claude/rules/web/security.md
+++ b/.claude/rules/web/security.md
@@ -1,3 +1,15 @@
+---
+paths:
+  - "**/*.css"
+  - "**/*.scss"
+  - "**/*.sass"
+  - "**/*.less"
+  - "**/*.html"
+  - "**/*.tsx"
+  - "**/*.jsx"
+  - "**/*.vue"
+  - "**/*.svelte"
+---
 > This file extends [common/security.md](../common/security.md) with web-specific security content.
 
 # Web Security Rules

--- a/.claude/rules/web/testing.md
+++ b/.claude/rules/web/testing.md
@@ -1,3 +1,15 @@
+---
+paths:
+  - "**/*.css"
+  - "**/*.scss"
+  - "**/*.sass"
+  - "**/*.less"
+  - "**/*.html"
+  - "**/*.tsx"
+  - "**/*.jsx"
+  - "**/*.vue"
+  - "**/*.svelte"
+---
 > This file extends [common/testing.md](../common/testing.md) with web-specific testing content.
 
 # Web Testing Rules

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -9,7 +9,7 @@ Write a handoff document summarising the current conversation so a fresh agent c
 
 Include a "suggested skills" section in the document, which suggests skills that the agent should invoke.
 
-Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
+Do not duplicate content already captured in other artifacts (specs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
 
 Redact any sensitive information, such as API keys, passwords, or personally identifiable information.
 

--- a/.zshrc
+++ b/.zshrc
@@ -42,8 +42,7 @@ bindkey "^e" edit-command-line
 # fresh machine never gets a broken terminal). Run `tmux` manually to fall
 # back to the old multiplexer during the trial.
 if [[ -z "$HERDR_ENV" && -z "$TMUX" ]] && command -v herdr >/dev/null 2>&1; then
-  herdr
-  exit
+  herdr && exit
 fi
 
 # enable direnv

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -16,6 +16,7 @@ panel_bg = "reset"
 # Prefix stays herdr's default ctrl+b (chosen over the old tmux C-t, which
 # frees the nvim <C-t> / nvim-tree collision). Set explicitly for clarity.
 prefix = "ctrl+b"
+rename_tab = "prefix+comma"
 # Left at herdr defaults because they already match the old tmux binds:
 #   focus panes  prefix+h/j/k/l   (was tmux `prefix h/j/k/l`)
 #   new tab      prefix+c         (was tmux `prefix c`)

--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -32,7 +32,7 @@
   "nvim-cmp": { "branch": "main", "commit": "a1d504892f2bc56c2e79b65c6faded2fd21f3eca" },
   "nvim-lint": { "branch": "master", "commit": "a219b2c9e5b4765e5c845aba119dad55806fcaf1" },
   "nvim-lsp-notify": { "branch": "main", "commit": "9541bdde0b84b7a33a24dbc2eccc3df33d4a0cdb" },
-  "nvim-lspconfig": { "branch": "master", "commit": "292f44408498103c47996ff5c18fd366293840d8" },
+  "nvim-lspconfig": { "branch": "master", "commit": "d224a1920728ba129880efc700d4a0180ac4ecbb" },
   "nvim-navic": { "branch": "master", "commit": "f5eba192f39b453675d115351808bd51276d9de5" },
   "nvim-notify": { "branch": "master", "commit": "8701bece920b38ea289b457f902e2ad184131a5d" },
   "nvim-tree.lua": { "branch": "master", "commit": "531b807b8f0d6f75016a0ee1e0cd5ce2086e9d95" },


### PR DESCRIPTION
## Summary

Housekeeping follow-ups after the tmux → herdr migration (which itself already shipped in #298). No new features — small config/rule tweaks only.

- **herdr**: `.zshrc` now runs `exit` only when `herdr` actually launches (`herdr && exit`), so a failed launch no longer closes the shell; add a `rename_tab = "prefix+comma"` keybind to `herdr/config.toml`.
- **Claude config**: add `paths:` frontmatter to the `.claude/rules/web/*` rules so they scope to web file globs (css/scss/sass/less/html/tsx/jsx/vue/svelte); reword the co-author attribution note in `git-workflow.md`; minor wording fix in the handoff skill ("PRD" → "specs").
- **nvim**: bump the `nvim-lspconfig` pin in `lazy-lock.json`.

## Test plan

- [x] `zsh -n .zshrc` parses cleanly
- [x] `gitleaks git --log-opts="origin/main..HEAD"` → no leaks
- [ ] `herdr/config.toml` loads without error (reload config / new session); `prefix+comma` renames the tab
- [ ] Fresh shell: `herdr && exit` launches herdr and only exits on success